### PR TITLE
create all threads

### DIFF
--- a/src/functions/server_functions/server_functions.c
+++ b/src/functions/server_functions/server_functions.c
@@ -173,7 +173,7 @@ int create_server(const int MESSAGE_SETTINGS)
     SERVER_ERROR("Error creating the server");
   }
 
-  for (count = 0; (int)count < total_threads-1; count++)
+  for (count = 0; (int)count < total_threads; count++)
   {
     if (pthread_create(&server_threads[count], NULL, socket_receive_data_thread, NULL) < 0 || pthread_detach(server_threads[count]) != 0)
     {


### PR DESCRIPTION
I expect the loop to create total_threads thread but it create total_threads-1.
Plus, if total_threads is 1 , no thread is created.