### PR TITLE
Added an extra replace in case the data is length is lower than 6

### DIFF
--- a/scripts/autoinstaller/autoinstaller.sh
+++ b/scripts/autoinstaller/autoinstaller.sh
@@ -1848,6 +1848,7 @@ function test_update()
   sleep 30s
   data=$(curl -s -X POST http://127.0.0.1:18281/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_block_count"}' -H 'Content-Type: application/json')
   data="${data:66:6}"
+  data="${data%,*}"
   data=$((data-XCASH_DPOPS_BLOCK_HEIGHT))
   sudo systemctl stop XCASH_Daemon
   sleep 30s


### PR DESCRIPTION
# Description

Test Update fails when the block height is still 5 digits or lower with an unexpected "," character. This is due to the 66:6 substring.

Fixes # (issue)

Added a removal of , and any characters behind it.
So 15000, -> 15000
164900, -> 164900
164900 -> 164900
400,"" -> 400

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running test_update while block height response is less than 6 digits.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
