### PR TITLE
autoinstaller.sh: remove previously downloaded bootstrap-file added

### DIFF
--- a/scripts/autoinstaller/autoinstaller.sh
+++ b/scripts/autoinstaller/autoinstaller.sh
@@ -1944,6 +1944,7 @@ function install_or_update_blockchain()
   if [ $XCASH_BLOCKCHAIN_INSTALLATION_DIR = "/" ]; then
   XCASH_BLOCKCHAIN_INSTALLATION_DIR="/root/.X-CASH/"
   fi
+  cd && rm xcash-blockchain.7z*
   wget -q http://94.130.59.172/xcash-blockchain.7z
   7z x xcash-blockchain.7z -o${XCASH_BLOCKCHAIN_INSTALLATION_DIR} &>/dev/null
   cd ${XCASH_BLOCKCHAIN_INSTALLATION_DIR}
@@ -1960,6 +1961,7 @@ function install_blockchain()
   if [ ! -d ${XCASH_BLOCKCHAIN_INSTALLATION_DIR} ]; then
     echo -ne "${COLOR_PRINT_YELLOW}Installing The BlockChain (This Might Take a While)${END_COLOR_PRINT}"
     cd $HOME
+    cd && rm xcash-blockchain.7z*
     wget -q http://94.130.59.172/xcash-blockchain.7z
     7z x xcash-blockchain.7z -o${XCASH_BLOCKCHAIN_INSTALLATION_DIR} &>/dev/null
     cd ${XCASH_BLOCKCHAIN_INSTALLATION_DIR}


### PR DESCRIPTION
Issue:
Interrupting the download of a bootstrap-file leaves an incomplete file on the server.
When the download process is repeated wget will save the new download as "original name + index".
When unpacking the bootstrap-file 7zip will try to unpack the incomplete file downloaded the first time and exit with an error.   

The added code removes eventually existing previously downloaded copies of the bootstrap.

# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
  

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
