### PR TITLE
Autoinstaller: Error when updating/downloading blockchain

### DIFF
--- a/scripts/autoinstaller/autoinstaller.sh
+++ b/scripts/autoinstaller/autoinstaller.sh
@@ -1948,7 +1948,7 @@ function install_or_update_blockchain()
   if [ $XCASH_BLOCKCHAIN_INSTALLATION_DIR = "/" ]; then
   XCASH_BLOCKCHAIN_INSTALLATION_DIR="/root/.X-CASH/"
   fi
-  cd && rm -rf xcash-blockchain.7z* || true
+  cd && rm xcash-blockchain.7z* || true
   wget -q http://94.130.59.172/xcash-blockchain.7z
   7z x xcash-blockchain.7z -o${XCASH_BLOCKCHAIN_INSTALLATION_DIR} &>/dev/null
   cd ${XCASH_BLOCKCHAIN_INSTALLATION_DIR}

--- a/scripts/autoinstaller/autoinstaller.sh
+++ b/scripts/autoinstaller/autoinstaller.sh
@@ -1948,7 +1948,7 @@ function install_or_update_blockchain()
   if [ $XCASH_BLOCKCHAIN_INSTALLATION_DIR = "/" ]; then
   XCASH_BLOCKCHAIN_INSTALLATION_DIR="/root/.X-CASH/"
   fi
-  cd && rm xcash-blockchain.7z*
+  cd && rm -rf xcash-blockchain.7z* || true
   wget -q http://94.130.59.172/xcash-blockchain.7z
   7z x xcash-blockchain.7z -o${XCASH_BLOCKCHAIN_INSTALLATION_DIR} &>/dev/null
   cd ${XCASH_BLOCKCHAIN_INSTALLATION_DIR}

--- a/scripts/autoinstaller/autoinstaller.sh
+++ b/scripts/autoinstaller/autoinstaller.sh
@@ -1948,7 +1948,7 @@ function install_or_update_blockchain()
   if [ $XCASH_BLOCKCHAIN_INSTALLATION_DIR = "/" ]; then
   XCASH_BLOCKCHAIN_INSTALLATION_DIR="/root/.X-CASH/"
   fi
-  cd && rm xcash-blockchain.7z* || true
+  cd && rm -rf xcash-blockchain.7z* || true
   wget -q http://94.130.59.172/xcash-blockchain.7z
   7z x xcash-blockchain.7z -o${XCASH_BLOCKCHAIN_INSTALLATION_DIR} &>/dev/null
   cd ${XCASH_BLOCKCHAIN_INSTALLATION_DIR}


### PR DESCRIPTION
# Description

When updating/downloading blockchain with the auto-installer: receiving "Installing / Updating The BlockChain (This Might Take a While)rm: cannot remove 'xcash-blockchain.7z*': No such file or directory", then the auto-installer closes.

Fixes # (issue)

added lines to ignore if the command 'rm' throws errors

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran updated autoinstaller.sh. No errors given

**Test Configuration**:
* Firmware version:
* Hardware:
  

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
