### PR TITLE
Fix some update height function thread unsafe probelm

### DIFF
--- a/src/XCASH_DPOPS.c
+++ b/src/XCASH_DPOPS.c
@@ -79,6 +79,7 @@ pthread_mutex_t vote_lock;
 pthread_mutex_t add_reserve_proof_lock;
 pthread_mutex_t invalid_reserve_proof_lock;
 pthread_mutex_t database_data_IP_address_lock;
+pthread_mutex_t update_current_block_height_lock;
 
 pthread_t server_threads[100];
 int epoll_fd;
@@ -206,6 +207,7 @@ void initialize_data(int parameters_count, char* parameters[])
   pthread_mutex_init(&add_reserve_proof_lock, NULL);
   pthread_mutex_init(&invalid_reserve_proof_lock, NULL);
   pthread_mutex_init(&database_data_IP_address_lock, NULL);
+  pthread_mutex_init(&update_current_block_height_lock, NULL);
 
   server_limit_IP_address_list = (char*)calloc(15728640,sizeof(char)); // 15 MB
   server_limit_public_address_list = (char*)calloc(15728640,sizeof(char)); // 15 MB

--- a/src/functions/network_functions/network_daemon_functions/network_daemon_functions.c
+++ b/src/functions/network_functions/network_daemon_functions/network_daemon_functions.c
@@ -32,6 +32,7 @@ Return: 1 if fully synced, 0 if not or an error
 
 int check_if_blockchain_is_fully_synced(void)
 {
+
   // Variables
   char data[SMALL_BUFFER_SIZE];
   int count;
@@ -40,11 +41,13 @@ int check_if_blockchain_is_fully_synced(void)
   
   memset(data,0,sizeof(data));
 
+  pthread_mutex_lock(&update_current_block_height_lock);
   // reset the block_verifiers_current_block_height
   for (count2 = 0; count2 < BLOCK_VERIFIERS_AMOUNT; count2++)
   {
     block_verifiers_current_block_height[count2] = 0;
   }
+  pthread_mutex_unlock(&update_current_block_height_lock);
 
   sscanf(current_block_height,"%zu",&block_height);
 
@@ -54,6 +57,7 @@ int check_if_blockchain_is_fully_synced(void)
   // send the message to all block verifiers. This function will wait until all messages have arrived
   block_verifiers_send_data_socket((const char*)data);
 
+  pthread_mutex_lock(&update_current_block_height_lock);
   // check if the blockchain is fully synced
   for (count = 0, count2 = 0; count < BLOCK_VERIFIERS_AMOUNT; count++)
   {
@@ -62,7 +66,7 @@ int check_if_blockchain_is_fully_synced(void)
       count2++;
     }
   }
-
+  pthread_mutex_unlock(&update_current_block_height_lock);
   return count2 >= BLOCK_VERIFIERS_VALID_AMOUNT ? 0 : 1;
 }
 

--- a/src/functions/server_functions/server_functions.c
+++ b/src/functions/server_functions/server_functions.c
@@ -616,7 +616,10 @@ void socket_thread(const int CLIENT_SOCKET)
  {
    if (server_limit_IP_addresses(1,(const char*)client_IP_address) == 1)
    {
+     pthread_mutex_lock(&update_current_block_height_lock);
      server_receive_data_socket_get_current_block_height((const char*)client_IP_address);
+     pthread_mutex_unlock(&update_current_block_height_lock);
+
      server_limit_IP_addresses(0,(const char*)client_IP_address);
    }
  } 
@@ -624,7 +627,10 @@ void socket_thread(const int CLIENT_SOCKET)
  {
    if (server_limit_IP_addresses(1,(const char*)client_IP_address) == 1)
    {
+     pthread_mutex_lock(&update_current_block_height_lock);
      server_receive_data_socket_send_current_block_height((const char*)buffer);
+     pthread_mutex_unlock(&update_current_block_height_lock);
+
      server_limit_IP_addresses(0,(const char*)client_IP_address);
    }
  } 

--- a/src/functions/server_functions/server_functions.c
+++ b/src/functions/server_functions/server_functions.c
@@ -616,10 +616,7 @@ void socket_thread(const int CLIENT_SOCKET)
  {
    if (server_limit_IP_addresses(1,(const char*)client_IP_address) == 1)
    {
-     pthread_mutex_lock(&update_current_block_height_lock);
      server_receive_data_socket_get_current_block_height((const char*)client_IP_address);
-     pthread_mutex_unlock(&update_current_block_height_lock);
-
      server_limit_IP_addresses(0,(const char*)client_IP_address);
    }
  } 

--- a/src/global_data/variables.h
+++ b/src/global_data/variables.h
@@ -50,6 +50,7 @@ extern pthread_mutex_t vote_lock;
 extern pthread_mutex_t add_reserve_proof_lock;
 extern pthread_mutex_t invalid_reserve_proof_lock;
 extern pthread_mutex_t database_data_IP_address_lock;
+extern pthread_mutex_t update_current_block_height_lock;
 
 extern pthread_t server_threads[100];
 extern int epoll_fd;


### PR DESCRIPTION
# Description

Fix some update height function thread unsafe probelm.

Fixes # (issue)

Multi-threaded operations on array variables may cause some buffer white bytes error.