### PR TITLE
Remote data

### DIFF
--- a/src/functions/block_verifiers_functions/block_verifiers_update_functions/block_verifiers_update_functions.c
+++ b/src/functions/block_verifiers_functions/block_verifiers_update_functions/block_verifiers_update_functions.c
@@ -1128,6 +1128,7 @@ int get_delegates_online_status(void)
     memcpy(delegates_online_status[count].public_address,delegates[count].public_address,strnlen(delegates[count].public_address,sizeof(delegates_online_status[count].public_address)));
     delegates_online_status[count].settings = 0;
 
+    memset(block_verifiers_send_data_socket[count].IP_address,0,sizeof(block_verifiers_send_data_socket[count].IP_address));
     memcpy(block_verifiers_send_data_socket[count].IP_address,delegates[count].IP_address,strnlen(delegates[count].IP_address,sizeof(block_verifiers_send_data_socket[count].IP_address)));
     block_verifiers_send_data_socket[count].settings = 0;
   }


### PR DESCRIPTION
# Description
Reverts a memset lost from my previous merge.

## Type of change
Adding a memset in block_verifiers_update_functions.c

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran as a delegate on the testnet

**Test Configuration**:
* Hardware: Ubuntu 20.04.4
