### PR TITLE
Fix file handle leak

### DIFF
--- a/src/functions/block_verifiers_functions/block_verifiers_functions.c
+++ b/src/functions/block_verifiers_functions/block_verifiers_functions.c
@@ -2539,6 +2539,8 @@ int block_verifiers_send_data_socket(const char* MESSAGE)
       close(block_verifiers_send_data_socket[count].socket);
     }
   }
+
+  close(epoll_fd_copy);
   return 1;
   
   #undef BLOCK_VERIFIERS_SEND_DATA_SOCKET

--- a/src/functions/block_verifiers_functions/block_verifiers_update_functions/block_verifiers_update_functions.c
+++ b/src/functions/block_verifiers_functions/block_verifiers_update_functions/block_verifiers_update_functions.c
@@ -1310,6 +1310,8 @@ int get_delegates_online_status(void)
     }
   }
   POINTER_RESET_DELEGATES_STRUCT(count,MAXIMUM_AMOUNT_OF_DELEGATES);
+
+  close(epoll_fd_copy);
   return total_delegates_online;
 
   #undef DATABASE_COLLECTION


### PR DESCRIPTION
# Description
File handle leak from epoll_create(). This PR adds close() calls for each epoll file handle. Over time xcash-dpops runs out of handles and loses the ability to open new sockets.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran on testnet